### PR TITLE
Feat/loading only area markers

### DIFF
--- a/Routes/PlaygroundRoutes.js
+++ b/Routes/PlaygroundRoutes.js
@@ -13,7 +13,7 @@ router.get("/api/playground/:longitude/:latitude", (req, res) => {
           type: "Polygon",
           coordinates: [Number(longitude), Number(latitude)],
         },
-        $maxDistance: 5000,
+        $maxDistance: 3000,
       },
     },
   })

--- a/Routes/PlaygroundRoutes.js
+++ b/Routes/PlaygroundRoutes.js
@@ -3,20 +3,22 @@ const User = require("../models/User");
 const express = require("express");
 const router = express.Router();
 
-router.get("/api/playground", (req, res) => {
+router.get("/api/playground/:longitude/:latitude", (req, res) => {
+  const { latitude } = req.params;
+  const { longitude } = req.params;
   Playground.find({
     geometry: {
       $nearSphere: {
         $geometry: {
-          type: "Point",
-          coordinates: [11.51617072678361, 48.11063608748793],
+          type: "Polygon",
+          coordinates: [Number(longitude), Number(latitude)],
         },
         $maxDistance: 5000,
       },
     },
   })
     .then((playground) => {
-      res.status(200).json(playground);
+      res.send(playground);
     })
     .catch(() => {
       res.status(500).json({

--- a/Routes/PlaygroundRoutes.js
+++ b/Routes/PlaygroundRoutes.js
@@ -4,7 +4,17 @@ const express = require("express");
 const router = express.Router();
 
 router.get("/api/playground", (req, res) => {
-  Playground.find({})
+  Playground.find({
+    geometry: {
+      $nearSphere: {
+        $geometry: {
+          type: "Point",
+          coordinates: [11.51617072678361, 48.11063608748793],
+        },
+        $maxDistance: 5000,
+      },
+    },
+  })
     .then((playground) => {
       res.status(200).json(playground);
     })

--- a/client/src/pages/Map.js
+++ b/client/src/pages/Map.js
@@ -36,7 +36,6 @@ export default function Map({ checkInState, checkOutState }) {
             .catch((error) => {
               console.error(error);
             });
-
           map.setView([newLatitude, newLongitude], 16);
         } else {
           toast.error(

--- a/client/src/pages/Map.js
+++ b/client/src/pages/Map.js
@@ -16,11 +16,12 @@ export default function Map({ checkInState, checkOutState }) {
   const localStorageUserId = JSON.parse(localStorage.getItem("userId"));
   const [updatePage, setUpdatePage] = useState();
   const [map, setMap] = useState(null);
+  // const [map2, setMap2] = useState(null);
   const [playGroundData, setPlayGroundData] = useState([]);
   const [dbUserId, setDbUserId] = useState(null);
 
-  useEffect(() => {
-    const url = "/api/playground";
+  document.addEventListener("DOMContentLoaded", function () {
+    const url = `/api/playground/8.6962945227448/50.11320252103816`;
     fetch(url)
       .then((res) => res.json())
       .then((allPlaygrounds) => {
@@ -28,8 +29,10 @@ export default function Map({ checkInState, checkOutState }) {
       })
       .catch((error) => {
         console.error(error);
+        console.log("that looks bad");
       });
-  }, []);
+  });
+
   //i could add "updatePage, checkOutState" inside the useeffect, in order to update the counter immediately
   //but it would rerender the whole map (very bad for performance)
 
@@ -41,6 +44,8 @@ export default function Map({ checkInState, checkOutState }) {
         if (searchedLocationData.length > 0) {
           const newLatitude = Number(searchedLocationData[0]?.lat);
           const newLongitude = Number(searchedLocationData[0]?.lon);
+          console.log(newLatitude);
+          console.log(newLongitude);
           map.setView([newLatitude, newLongitude], 15);
         } else {
           toast.error(
@@ -133,6 +138,7 @@ export default function Map({ checkInState, checkOutState }) {
         whenCreated={setMap}
         loadingControl={true}
         scrollWheelZoom={false}
+        // onDragEnd={setMap2}
       >
         <TileLayer
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'

--- a/client/src/pages/Map.js
+++ b/client/src/pages/Map.js
@@ -16,7 +16,6 @@ export default function Map({ checkInState, checkOutState }) {
   const localStorageUserId = JSON.parse(localStorage.getItem("userId"));
   const [updatePage, setUpdatePage] = useState();
   const [map, setMap] = useState(null);
-  // const [map2, setMap2] = useState(null);
   const [playGroundData, setPlayGroundData] = useState([]);
   const [dbUserId, setDbUserId] = useState(null);
 
@@ -36,7 +35,6 @@ export default function Map({ checkInState, checkOutState }) {
             })
             .catch((error) => {
               console.error(error);
-              console.log("that looks bad");
             });
 
           map.setView([newLatitude, newLongitude], 16);
@@ -131,7 +129,6 @@ export default function Map({ checkInState, checkOutState }) {
         whenCreated={setMap}
         loadingControl={true}
         scrollWheelZoom={false}
-        // onDragEnd={setMap2}
       >
         <TileLayer
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'

--- a/client/src/pages/Map.js
+++ b/client/src/pages/Map.js
@@ -20,7 +20,7 @@ export default function Map({ checkInState, checkOutState }) {
   const [playGroundData, setPlayGroundData] = useState([]);
   const [dbUserId, setDbUserId] = useState(null);
 
-  document.addEventListener("DOMContentLoaded", function () {
+  useEffect(() => {
     const url = `/api/playground/8.6962945227448/50.11320252103816`;
     fetch(url)
       .then((res) => res.json())
@@ -31,8 +31,7 @@ export default function Map({ checkInState, checkOutState }) {
         console.error(error);
         console.log("that looks bad");
       });
-  });
-
+  }, []);
   //i could add "updatePage, checkOutState" inside the useeffect, in order to update the counter immediately
   //but it would rerender the whole map (very bad for performance)
 
@@ -44,8 +43,6 @@ export default function Map({ checkInState, checkOutState }) {
         if (searchedLocationData.length > 0) {
           const newLatitude = Number(searchedLocationData[0]?.lat);
           const newLongitude = Number(searchedLocationData[0]?.lon);
-          console.log(newLatitude);
-          console.log(newLongitude);
           map.setView([newLatitude, newLongitude], 15);
         } else {
           toast.error(

--- a/client/src/pages/Map.js
+++ b/client/src/pages/Map.js
@@ -21,21 +21,6 @@ export default function Map({ checkInState, checkOutState }) {
   const [dbUserId, setDbUserId] = useState(null);
 
   useEffect(() => {
-    const url = `/api/playground/8.6962945227448/50.11320252103816`;
-    fetch(url)
-      .then((res) => res.json())
-      .then((allPlaygrounds) => {
-        setPlayGroundData(allPlaygrounds);
-      })
-      .catch((error) => {
-        console.error(error);
-        console.log("that looks bad");
-      });
-  }, []);
-  //i could add "updatePage, checkOutState" inside the useeffect, in order to update the counter immediately
-  //but it would rerender the whole map (very bad for performance)
-
-  useEffect(() => {
     const searchInputUrl = `https://nominatim.openstreetmap.org/search?q=${locationSearchValue}&limit=20&format=json`;
     fetch(searchInputUrl)
       .then((res) => res.json())
@@ -43,7 +28,18 @@ export default function Map({ checkInState, checkOutState }) {
         if (searchedLocationData.length > 0) {
           const newLatitude = Number(searchedLocationData[0]?.lat);
           const newLongitude = Number(searchedLocationData[0]?.lon);
-          map.setView([newLatitude, newLongitude], 15);
+          const url = `/api/playground/${newLongitude}/${newLatitude}`;
+          fetch(url)
+            .then((res) => res.json())
+            .then((allPlaygrounds) => {
+              setPlayGroundData(allPlaygrounds);
+            })
+            .catch((error) => {
+              console.error(error);
+              console.log("that looks bad");
+            });
+
+          map.setView([newLatitude, newLongitude], 16);
         } else {
           toast.error(
             "Leider konnten wir mit deiner Suchanfrage nichts finden. Versuche es nochmal."

--- a/playground.http
+++ b/playground.http
@@ -1,6 +1,15 @@
 ###get all articles
 GET http://localhost:4000/api/playground HTTP/1.1
 
+###test
+GET http://localhost:4000/api/playground HTTP/1.1
+Content-Type: application/json
+
+{
+  "nominatim1" : "1",
+  "nominatim2" : "2"
+}
+
 ### User infos
 GET http://localhost:4000/api/users/622afe4c-628d-40c8-9731-56c9af052679 HTTP/1.1
 


### PR DESCRIPTION
i added around 20k playgrounds in some german cities (Hamburg, Berlin, Munich) in the database
- since the app was very laggy when loading 20k playgrounds, i added a feature, where only the markers within a 3km radius of the given location are beeing shown.
